### PR TITLE
Fix analytics by using arguments

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -54,12 +54,12 @@ const { title, description, image = '/portfolioog.jpg' } = Astro.props
 	src="https://www.googletagmanager.com/gtag/js?id=G-8Q4KF722K3"></script>
 
 <script type="text/partytown">
-  window.dataLayer = window.dataLayer || []
-  function gtag() {
+	window.dataLayer = window.dataLayer || []
+	function gtag() {
 		/* eslint-disable-next-line prefer-rest-params */
-    dataLayer.push(arguments)
-  }
-  gtag('js', new Date())
+		dataLayer.push(arguments)
+	}
+	gtag('js', new Date())
 
-  gtag('config', 'G-8Q4KF722K3')
+	gtag('config', 'G-8Q4KF722K3')
 </script>


### PR DESCRIPTION
closes #20 

Refactor the gtag function to enhance argument handling by using `arguments` instead of rest parameters, ensuring better compatibility with various argument types.