### PR TITLE
Readd home link to navbar

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -26,6 +26,10 @@ export const SocialLinks = [
 
 export const WebsiteLinks = [
 	{
+		name: 'Home',
+		url: '/',
+	},
+	{
 		name: 'Blog',
 		url: '/blog',
 	},


### PR DESCRIPTION
Adds explicit link to website `Home`
Was removed previously for simplicity but can cause confusion to mobile users