### PR TITLE
Include `h3` in `TableOfContents` & smooth scroll behavior for scroll links

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -7,22 +7,46 @@ interface Props {
 
 const { headings } = Astro.props
 
-const filteredHeadings = headings.filter((heading) => heading.depth <= 2)
+// Group headings: h2 as top-level, h3 as nested under previous h2
+interface TOCHeading extends MarkdownHeading {
+	children: MarkdownHeading[]
+}
+const toc: TOCHeading[] = []
+let lastH2: TOCHeading | null = null
+for (const heading of headings) {
+	if (heading.depth === 2) {
+		lastH2 = { ...heading, children: [] }
+		toc.push(lastH2)
+	} else if (heading.depth === 3 && lastH2) {
+		lastH2.children.push(heading)
+	}
+}
 ---
 
 {
-	filteredHeadings.length > 0 ? (
+	toc.length > 0 ? (
 		<nav class="py-12 rounded">
 			<h2 class="text-2xl mr-2 pb-1 mb-3 font-bold">On This Page</h2>
 			<ul class="space-y-3">
-				{filteredHeadings.map((heading) => (
+				{toc.map((h2) => (
 					<li>
-						<a
-							class="hover:underline underline-offset-4"
-							href={`#${heading.slug}`}
-						>
-							{heading.text}
+						<a class="hover:underline underline-offset-4" href={`#${h2.slug}`}>
+							{h2.text}
 						</a>
+						{h2.children.length > 0 && (
+							<ul class="ml-4 mt-2 space-y-2 border-l border-gray-300 dark:border-gray-700 pl-4">
+								{h2.children.map((h3) => (
+									<li>
+										<a
+											class="hover:underline underline-offset-4 text-sm opacity-80"
+											href={`#${h3.slug}`}
+										>
+											{h3.text}
+										</a>
+									</li>
+								))}
+							</ul>
+						)}
 					</li>
 				))}
 			</ul>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,11 @@
 	--color-primary-dark: #9bd4e4;
 }
 
+html {
+	scroll-padding-top: 6.5rem;
+	scroll-behavior: smooth;
+}
+
 .app-container {
 	@apply container mx-auto px-6 sm:px-12 2xl:px-16;
 }


### PR DESCRIPTION
This pull request refactors the `TableOfContents` component to improve the structure and usability of the table of contents, and enhances user experience by enabling smooth scrolling and appropriate scroll padding. The main changes include grouping headings for better navigation and updating global styles for improved scrolling behavior.

**Table of Contents Improvements**
* Grouped headings in `TableOfContents.astro` so that `h2` elements are top-level entries and `h3` elements are nested under the previous `h2`, making the table of contents more organized and easier to navigate.
* Updated the rendering logic to display nested lists for `h3` headings under their respective `h2` parents, improving readability and structure.

**User Experience Enhancements**
* Added `scroll-padding-top` and `scroll-behavior: smooth` to the global CSS (`global.css`) to ensure smooth scrolling and that headings are not hidden behind fixed headers when navigating via the table of contents.