### PR TITLE
Fix layout issues on 404 page and blog post title

### DIFF
--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -53,7 +53,7 @@ const lastModified = dayjs(remarkPluginFrontmatter.lastModified)
 				</div>
 				<div class="grow w-full md:max-w-[75ch]">
 					<div>
-						<h1 class="text-5xl leading-snug pt-12 font-bold">
+						<h1 class="text-4xl sm:text-5xl leading-snug pt-12 font-bold">
 							{title}
 						</h1>
 						<div class="text-lg flex items-center gap-4 flex-wrap py-8">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 ---
 
 <BaseLayout>
-	<div class="bg-background">
+	<div>
 		<main
 			class="app-container h-[95vh] flex flex-col gap-6 justify-center py-56 items-center"
 		>


### PR DESCRIPTION
Remove unnecessary background class from the 404 page layout and adjust the heading size for better readability of blog post titles.

closes #49